### PR TITLE
chore: remove "main" package field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "engines": {
     "node": ">=18.16.0"
   },
-  "main": "build/index.js",
   "type": "module",
   "files": [
     "build/src",


### PR DESCRIPTION
It's ignored if `exports` exists.
